### PR TITLE
docs: expand tests and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,57 @@
-This is a typescript utility package that does the following:
+# convert_axios_http
 
-1. Given a raw http request (an array buffer of bytes), convert it to an axios request object
-2. Given an axios request object, convert it to a raw http bytes
-3. Given a raw http response (as an arraybuffer of bytes), convert it to an axios response object
-4. Given a axios response object, convert it to an array of bytes that represents a full http response bytes (as an arraybuffer)
+A TypeScript utility that converts between raw HTTP messages and axios request/response objects.
 
+## Features
 
-In additional to all the regular stuff, it handles basic multipart forms and file uploads.
+- Convert a raw HTTP request (ArrayBuffer of bytes) into an axios request object.
+- Convert an axios request object into raw HTTP bytes.
+- Convert a raw HTTP response (ArrayBuffer of bytes) into an axios response object.
+- Convert an axios response object into raw HTTP bytes.
+
+Supports multipart forms and basic file uploads in both directions.
+
+## Installation
+
+```bash
+npm install convert_axios_http
+```
+
+## Usage
+
+### Converting requests
 
 ```ts
 import {
   rawHttpRequestToAxiosRequest,
   axiosRequestToRawHttp,
-  rawHttpResponseToAxiosResponse,
-  axiosResponseToRawHttp,
 } from 'convert_axios_http';
 
 const raw = axiosRequestToRawHttp({ method: 'get', url: '/' });
 const req = rawHttpRequestToAxiosRequest(raw);
+```
+
+### Converting responses
+
+```ts
+import {
+  rawHttpResponseToAxiosResponse,
+  axiosResponseToRawHttp,
+} from 'convert_axios_http';
+
+const rawRes = axiosResponseToRawHttp({
+  data: { ok: true },
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: {},
+});
+const res = rawHttpResponseToAxiosResponse(rawRes);
+```
+
+## Running tests
+
+```bash
+npm test
 ```
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -23,6 +23,16 @@ describe('rawHttpRequestToAxiosRequest', () => {
     expect(req.headers?.host).toBe('example.com');
   });
 
+  it('parses JSON body', () => {
+    const raw = toArrayBuffer(
+      'POST /json HTTP/1.1\r\nContent-Type: application/json\r\n\r\n{"a":1}',
+    );
+    const req = rawHttpRequestToAxiosRequest(raw);
+    expect(req.method).toBe('POST');
+    expect(req.url).toBe('/json');
+    expect(req.data).toEqual({ a: 1 });
+  });
+
   it('parses multipart form data', () => {
     const boundary = '----WebKitFormBoundary7MA4YWxkTrZu0gW';
     const rawStr =
@@ -117,6 +127,16 @@ describe('axiosRequestToRawHttp', () => {
     });
     const str = Buffer.from(raw).toString();
     expect(str.startsWith('GET /path?x=1 HTTP/1.1')).toBe(true);
+  });
+
+  it('includes host header when provided', () => {
+    const raw = axiosRequestToRawHttp({
+      method: 'get',
+      url: '/',
+      headers: { Host: 'example.com' },
+    });
+    const str = Buffer.from(raw).toString();
+    expect(str.toLowerCase()).toContain('\r\nhost: example.com\r\n');
   });
 
   it('does not override provided content-length', () => {


### PR DESCRIPTION
## Summary
- add JSON parsing and host header tests
- document usage and testing in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b34417d0e88323b0a1ca09feead4b1